### PR TITLE
Force LF line ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.sh text


### PR DESCRIPTION
RCLF can break sh files.
LF is the better standard so we will be using that going forward.

This should be done in two commits but I am afraid that git will see an empty commit